### PR TITLE
Add Ritual Bowl

### DIFF
--- a/src/main/kotlin/com/reicheltp/celtic_rituals/init/ModBlocks.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/init/ModBlocks.kt
@@ -1,0 +1,11 @@
+package com.reicheltp.celtic_rituals.init
+
+
+import net.minecraft.block.Block
+import net.minecraftforge.registries.ObjectHolder
+
+object ModBlocks {
+
+    @ObjectHolder("celtic_rituals:ritual_bowl")
+    var RITUAL_BOWL: Block? = null
+}

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/init/ModBlocks.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/init/ModBlocks.kt
@@ -2,10 +2,14 @@ package com.reicheltp.celtic_rituals.init
 
 
 import net.minecraft.block.Block
+import net.minecraft.tileentity.TileEntityType
 import net.minecraftforge.registries.ObjectHolder
 
 object ModBlocks {
 
     @ObjectHolder("celtic_rituals:ritual_bowl")
     var RITUAL_BOWL: Block? = null
+
+    @ObjectHolder("celtic_rituals:ritual_bowl")
+    var RITUAL_BOWL_TILE: TileEntityType<*>? = null
 }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/proxy/CommonProxy.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/proxy/CommonProxy.kt
@@ -1,8 +1,13 @@
 package com.reicheltp.celtic_rituals.proxy
 
+import com.reicheltp.celtic_rituals.MOD_ID
+import com.reicheltp.celtic_rituals.init.ModBlocks
 import com.reicheltp.celtic_rituals.items.Knife
+import com.reicheltp.celtic_rituals.rituals.bowl.RitualBowlBlock
 import net.minecraft.block.Block
+import net.minecraft.item.BlockItem
 import net.minecraft.item.Item
+import net.minecraft.util.ResourceLocation
 import net.minecraftforge.event.RegistryEvent
 import net.minecraftforge.eventbus.api.SubscribeEvent
 
@@ -14,13 +19,17 @@ import net.minecraftforge.eventbus.api.SubscribeEvent
  */
 abstract class CommonProxy {
     @SubscribeEvent
-    fun onBlocksRegistry(blockRegistryEvent: RegistryEvent.Register<Block>) {
+    fun onBlocksRegistry(event: RegistryEvent.Register<Block>) {
+        event.registry.registerAll(
+                RitualBowlBlock()
+        )
     }
 
     @SubscribeEvent
     fun registerItems(event: RegistryEvent.Register<Item>) {
         event.registry.registerAll(
-                Knife()
+                Knife(),
+                BlockItem(ModBlocks.RITUAL_BOWL!!, Item.Properties().maxStackSize(1)).setRegistryName(ResourceLocation(MOD_ID, "ritual_bowl"))
         )
     }
 }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/proxy/CommonProxy.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/proxy/CommonProxy.kt
@@ -4,12 +4,16 @@ import com.reicheltp.celtic_rituals.MOD_ID
 import com.reicheltp.celtic_rituals.init.ModBlocks
 import com.reicheltp.celtic_rituals.items.Knife
 import com.reicheltp.celtic_rituals.rituals.bowl.RitualBowlBlock
+import com.reicheltp.celtic_rituals.rituals.bowl.RitualBowlTile
 import net.minecraft.block.Block
 import net.minecraft.item.BlockItem
 import net.minecraft.item.Item
+import net.minecraft.tileentity.TileEntityType
 import net.minecraft.util.ResourceLocation
 import net.minecraftforge.event.RegistryEvent
 import net.minecraftforge.eventbus.api.SubscribeEvent
+import java.util.function.Supplier
+
 
 /**
  * Register stuff we need on client and server side.
@@ -24,6 +28,14 @@ abstract class CommonProxy {
                 RitualBowlBlock()
         )
     }
+
+    @SubscribeEvent
+    fun onTileEntityRegistry(event: RegistryEvent.Register<TileEntityType<*>>) {
+        event.registry.register(
+                TileEntityType.Builder.create(Supplier { RitualBowlTile() }, ModBlocks.RITUAL_BOWL).build(null).setRegistryName(ResourceLocation(MOD_ID, "ritual_bowl"))
+        )
+    }
+
 
     @SubscribeEvent
     fun registerItems(event: RegistryEvent.Register<Item>) {

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowl.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowl.kt
@@ -1,0 +1,41 @@
+package com.reicheltp.celtic_rituals.rituals.bowl
+
+import com.reicheltp.celtic_rituals.MOD_ID
+import net.minecraft.block.Block
+import net.minecraft.block.BlockState
+import net.minecraft.block.SoundType
+import net.minecraft.block.material.Material
+import net.minecraft.util.ResourceLocation
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.shapes.ISelectionContext
+import net.minecraft.util.math.shapes.VoxelShape
+import net.minecraft.world.IBlockReader
+
+/**
+ * Central item required to perform rituals.
+ *
+ * The player puts all his items in a ritual bowl and burn it afterward.
+ */
+class RitualBowlBlock : Block(
+        Properties.create(Material.WOOD)
+                .variableOpacity()
+                .hardnessAndResistance(1.0f)
+                .sound(SoundType.WOOD)
+) {
+    companion object {
+        private val SHAPE = makeCuboidShape(.0, .0, .0, 16.0, 8.0, 16.0)
+    }
+
+    init {
+        registryName = ResourceLocation(MOD_ID, "ritual_bowl")
+    }
+
+    override fun isSolid(state: BlockState): Boolean {
+        // TODO: This seems to be deprecated. We should discover a better way.
+        return false
+    }
+
+    override fun getShape(state: BlockState, worldIn: IBlockReader, pos: BlockPos, context: ISelectionContext): VoxelShape {
+        return SHAPE
+    }
+}

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlBlock.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlBlock.kt
@@ -1,24 +1,34 @@
 package com.reicheltp.celtic_rituals.rituals.bowl
 
 import com.reicheltp.celtic_rituals.MOD_ID
+import com.reicheltp.celtic_rituals.init.ModBlocks
 import com.reicheltp.celtic_rituals.utils.canBeCombined
+import net.minecraft.advancements.CriteriaTriggers
 import net.minecraft.block.Block
 import net.minecraft.block.BlockState
+import net.minecraft.block.Blocks
 import net.minecraft.block.SoundType
 import net.minecraft.block.material.Material
 import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.entity.player.ServerPlayerEntity
+import net.minecraft.inventory.EquipmentSlotType
 import net.minecraft.inventory.InventoryHelper
 import net.minecraft.inventory.ItemStackHelper
+import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
+import net.minecraft.state.StateContainer
+import net.minecraft.state.properties.BlockStateProperties
 import net.minecraft.tileentity.TileEntity
-import net.minecraft.util.Hand
-import net.minecraft.util.ResourceLocation
+import net.minecraft.util.*
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.BlockRayTraceResult
 import net.minecraft.util.math.shapes.ISelectionContext
 import net.minecraft.util.math.shapes.VoxelShape
 import net.minecraft.world.IBlockReader
+import net.minecraft.world.IEnviromentBlockReader
+import net.minecraft.world.IWorldReader
 import net.minecraft.world.World
+import java.util.*
 
 /**
  * Central item required to perform rituals.
@@ -29,28 +39,38 @@ class RitualBowlBlock : Block(
         Properties.create(Material.WOOD)
                 .variableOpacity()
                 .hardnessAndResistance(1.0f)
+                .lightValue(14)
                 .sound(SoundType.WOOD)
 ) {
     companion object {
         private val SHAPE = makeCuboidShape(.0, .0, .0, 16.0, 8.0, 16.0)
+        private val random = Random()
     }
 
     init {
         registryName = ResourceLocation(MOD_ID, "ritual_bowl")
-    }
-
-    override fun isSolid(state: BlockState): Boolean {
-        // TODO: This seems to be deprecated. We should discover a better way.
-        return false
+        defaultState = stateContainer.baseState.with(BlockStateProperties.ENABLED, false)
     }
 
     override fun getShape(state: BlockState, worldIn: IBlockReader, pos: BlockPos, context: ISelectionContext): VoxelShape {
         return SHAPE
     }
 
+    override fun getRenderLayer(): BlockRenderLayer {
+        return BlockRenderLayer.CUTOUT
+    }
+
+    override fun getLightValue(state: BlockState?, world: IEnviromentBlockReader?, pos: BlockPos?): Int {
+        return if (state!!.get(BlockStateProperties.ENABLED)) super.getLightValue(state, world, pos) else 0
+    }
+
     override fun hasTileEntity(state: BlockState?): Boolean = true
 
     override fun createTileEntity(state: BlockState?, world: IBlockReader?): TileEntity? = RitualBowlTile()
+
+    override fun fillStateContainer(builder: StateContainer.Builder<Block, BlockState>) {
+        builder.add(BlockStateProperties.ENABLED)
+    }
 
     /**
      * Drops all stored items when block gets replaced.
@@ -59,12 +79,16 @@ class RitualBowlBlock : Block(
      */
     override fun onReplaced(state: BlockState, worldIn: World, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
         if (state.block !== newState.block) {
-            val tile = worldIn.getTileEntity(pos)
-            if (tile is RitualBowlTile) {
-                for (i in 0 until tile.getSizeInventory()) {
-                    InventoryHelper.spawnItemStack(worldIn, pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble(), tile.getStackInSlot(i))
+            if (state.get(BlockStateProperties.ENABLED)) {
+                worldIn.setBlockState(pos, Blocks.FIRE.defaultState)
+            } else {
+                val tile = worldIn.getTileEntity(pos)
+                if (tile is RitualBowlTile) {
+                    for (i in 0 until tile.getSizeInventory()) {
+                        InventoryHelper.spawnItemStack(worldIn, pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble(), tile.getStackInSlot(i))
+                    }
+                    worldIn.updateComparatorOutputLevel(pos, this)
                 }
-                worldIn.updateComparatorOutputLevel(pos, this)
             }
 
             super.onReplaced(state, worldIn, pos, newState, isMoving)
@@ -81,13 +105,43 @@ class RitualBowlBlock : Block(
             return false
         }
 
+        val inProgress = state.get(BlockStateProperties.ENABLED)
+
+        // Extinguishes an ignited bowl, but removes all items.
+        if (player.heldItemMainhand.item == Items.WATER_BUCKET) {
+            worldIn.playSound(player, pos, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.BLOCKS, 0.5f, 2.6f + (random.nextFloat() - random.nextFloat()) * 0.8f)
+
+            if (inProgress) {
+                worldIn.setBlockState(pos, state.with(BlockStateProperties.ENABLED, false))
+            }
+
+            player.setItemStackToSlot(EquipmentSlotType.MAINHAND, ItemStack(Items.BUCKET))
+
+            tile.clear()
+
+            return true
+        }
+
+        // Ignites the bowl
         if (player.heldItemMainhand.item == Items.FLINT_AND_STEEL) {
             // TODO: This will ignite the bowl and start a ritual
-            return false
+            worldIn.playSound(player, pos, SoundEvents.ITEM_FLINTANDSTEEL_USE, SoundCategory.BLOCKS, 1.0f, random.nextFloat() * 0.4f + 0.8f)
+
+            if (player is ServerPlayerEntity) {
+                CriteriaTriggers.PLACED_BLOCK.trigger(player, pos, player.heldItemMainhand)
+                player.heldItemMainhand.damageItem(1, player, { it.sendBreakAnimation(handIn) })
+            }
+
+            if (!inProgress) {
+                worldIn.setBlockState(pos, state.with(BlockStateProperties.ENABLED, true))
+                worldIn.pendingBlockTicks.scheduleTick(pos, ModBlocks.RITUAL_BOWL!!, 200)
+            }
+
+            return true
         }
 
         // Sneak pick pulls a stack from bowl
-        if (player.heldItemMainhand.isEmpty && player.isSneaking) {
+        if (!inProgress && player.heldItemMainhand.isEmpty && player.isSneaking) {
             for (i in 0 until tile.getSizeInventory()) {
                 val stack = tile.getStackInSlot(i)
                 if (stack.isEmpty) {
@@ -98,26 +152,36 @@ class RitualBowlBlock : Block(
             }
         }
 
-        // Use item on bowl puts it in
-        for (i in 0 until tile.getSizeInventory()) {
-            val stack = tile.getStackInSlot(i)
+        if (!inProgress) {
+            // Use item on bowl puts it in
+            for (i in 0 until tile.getSizeInventory()) {
+                val stack = tile.getStackInSlot(i)
 
-            when {
-                stack.isEmpty -> {
-                    val item = player.heldItemMainhand.split(1)
-                    tile.setInventorySlotContents(i, item)
+                when {
+                    stack.isEmpty -> {
+                        val item = player.heldItemMainhand.split(1)
+                        tile.setInventorySlotContents(i, item)
 
-                    return true
-                }
-                stack.canBeCombined(player.heldItemMainhand) -> {
-                    player.heldItemMainhand.shrink(1)
-                    stack.grow(1)
+                        return true
+                    }
+                    stack.canBeCombined(player.heldItemMainhand) -> {
+                        player.heldItemMainhand.shrink(1)
+                        stack.grow(1)
 
-                    return true
+                        return true
+                    }
                 }
             }
         }
 
         return false
+    }
+
+    override fun tick(state: BlockState, worldIn: World, pos: BlockPos, random: Random) {
+        worldIn.setBlockState(pos, state.with(BlockStateProperties.ENABLED, false))
+
+        // TODO: Craft the item / Perform the ritual
+
+        super.tick(state, worldIn, pos, random)
     }
 }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlBlock.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlBlock.kt
@@ -5,6 +5,7 @@ import net.minecraft.block.Block
 import net.minecraft.block.BlockState
 import net.minecraft.block.SoundType
 import net.minecraft.block.material.Material
+import net.minecraft.tileentity.TileEntity
 import net.minecraft.util.ResourceLocation
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.shapes.ISelectionContext
@@ -30,7 +31,7 @@ class RitualBowlBlock : Block(
         registryName = ResourceLocation(MOD_ID, "ritual_bowl")
     }
 
-    override fun isSolid(state: BlockState): Boolean {
+   override fun isSolid(state: BlockState): Boolean {
         // TODO: This seems to be deprecated. We should discover a better way.
         return false
     }
@@ -38,4 +39,8 @@ class RitualBowlBlock : Block(
     override fun getShape(state: BlockState, worldIn: IBlockReader, pos: BlockPos, context: ISelectionContext): VoxelShape {
         return SHAPE
     }
+
+    override fun hasTileEntity(state: BlockState?): Boolean = true
+
+    override fun createTileEntity(state: BlockState?, world: IBlockReader?): TileEntity? = RitualBowlTile()
 }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlBlock.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlBlock.kt
@@ -80,14 +80,12 @@ class RitualBowlBlock : Block(
     override fun onReplaced(state: BlockState, worldIn: World, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
         if (state.block !== newState.block) {
             if (state.get(BlockStateProperties.ENABLED)) {
+                // Destroying a running ritual will loose all items
                 worldIn.setBlockState(pos, Blocks.FIRE.defaultState)
             } else {
                 val tile = worldIn.getTileEntity(pos)
                 if (tile is RitualBowlTile) {
-                    for (i in 0 until tile.getSizeInventory()) {
-                        InventoryHelper.spawnItemStack(worldIn, pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble(), tile.getStackInSlot(i))
-                    }
-                    worldIn.updateComparatorOutputLevel(pos, this)
+                    InventoryHelper.dropInventoryItems(worldIn, pos, tile)
                 }
             }
 
@@ -142,7 +140,7 @@ class RitualBowlBlock : Block(
 
         // Sneak pick pulls a stack from bowl
         if (!inProgress && player.heldItemMainhand.isEmpty && player.isSneaking) {
-            for (i in 0 until tile.getSizeInventory()) {
+            for (i in 0 until tile.sizeInventory) {
                 val stack = tile.getStackInSlot(i)
                 if (stack.isEmpty) {
                     continue
@@ -154,7 +152,7 @@ class RitualBowlBlock : Block(
 
         if (!inProgress) {
             // Use item on bowl puts it in
-            for (i in 0 until tile.getSizeInventory()) {
+            for (i in 0 until tile.sizeInventory) {
                 val stack = tile.getStackInSlot(i)
 
                 when {

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlBlock.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlBlock.kt
@@ -5,12 +5,14 @@ import net.minecraft.block.Block
 import net.minecraft.block.BlockState
 import net.minecraft.block.SoundType
 import net.minecraft.block.material.Material
+import net.minecraft.inventory.InventoryHelper
 import net.minecraft.tileentity.TileEntity
 import net.minecraft.util.ResourceLocation
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.shapes.ISelectionContext
 import net.minecraft.util.math.shapes.VoxelShape
 import net.minecraft.world.IBlockReader
+import net.minecraft.world.World
 
 /**
  * Central item required to perform rituals.
@@ -31,7 +33,7 @@ class RitualBowlBlock : Block(
         registryName = ResourceLocation(MOD_ID, "ritual_bowl")
     }
 
-   override fun isSolid(state: BlockState): Boolean {
+    override fun isSolid(state: BlockState): Boolean {
         // TODO: This seems to be deprecated. We should discover a better way.
         return false
     }
@@ -43,4 +45,23 @@ class RitualBowlBlock : Block(
     override fun hasTileEntity(state: BlockState?): Boolean = true
 
     override fun createTileEntity(state: BlockState?, world: IBlockReader?): TileEntity? = RitualBowlTile()
+
+    /**
+     * Drops all stored items when block gets replaced.
+     *
+     * Borrowed from AbstractFurnaceBlock
+     */
+    override fun onReplaced(state: BlockState, worldIn: World, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
+        if (state.block !== newState.block) {
+            val tile = worldIn.getTileEntity(pos)
+            if (tile is RitualBowlTile) {
+                for (i in 0 until tile.getSizeInventory()) {
+                    InventoryHelper.spawnItemStack(worldIn, pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble(), tile.getStackInSlot(i))
+                }
+                worldIn.updateComparatorOutputLevel(pos, this)
+            }
+
+            super.onReplaced(state, worldIn, pos, newState, isMoving)
+        }
+    }
 }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
@@ -2,21 +2,56 @@ package com.reicheltp.celtic_rituals.rituals.bowl
 
 import com.reicheltp.celtic_rituals.init.ModBlocks
 import net.minecraft.inventory.IInventory
-import net.minecraft.inventory.ItemStackHelper
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.tileentity.ITickableTileEntity
 import net.minecraft.tileentity.TileEntity
-import net.minecraft.util.NonNullList
-import java.util.logging.LogManager
+import net.minecraft.util.Direction
+import net.minecraftforge.common.capabilities.Capability
+import net.minecraftforge.common.util.LazyOptional
+import net.minecraftforge.items.CapabilityItemHandler
+import net.minecraftforge.items.ItemStackHandler
 
 /**
  * TileEntity for @see RitualBowlBlock entity.
  */
 class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), ITickableTileEntity {
+    // The item handler capability keeps
+    private val incredients = LazyOptional.of { ItemStackHandler(5) }
+
     override fun tick() {
         if(world?.isRemote == true){
             System.out.println("TICK")
+    /**
+     * Used when world is loaded an the tile entity is reconstructed.
+     */
+    override fun read(tag: CompoundNBT) {
+        incredients.ifPresent { it.deserializeNBT(tag.getCompound("inv")) }
+        super.read(tag)
+    }
+
+    /**
+     * Used when world is saved. We have to store all data we want to keep over the world
+     */
+    override fun write(tag: CompoundNBT): CompoundNBT {
+        incredients.ifPresent { tag.put("inv", it.serializeNBT()) }
+        return super.write(tag)
+    }
+
+    /**
+     *
+     */
+    override fun <T : Any?> getCapability(cap: Capability<T>, side: Direction?): LazyOptional<T> {
+        if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return incredients.cast()
         }
+
+        return super.getCapability(cap, side)
+        }
+
+    override fun remove() {
+        incredients.invalidate()
+
+        super.remove()
     }
 }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
@@ -1,7 +1,6 @@
 package com.reicheltp.celtic_rituals.rituals.bowl
 
 import com.reicheltp.celtic_rituals.init.ModBlocks
-import net.minecraft.inventory.IInventory
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.tileentity.ITickableTileEntity
@@ -17,7 +16,7 @@ import net.minecraftforge.items.ItemStackHandler
  */
 class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), ITickableTileEntity {
     // The item handler capability keeps
-    private val incredients = LazyOptional.of { ItemStackHandler(5) }
+    private val ingredients = LazyOptional.of { ItemStackHandler(5) }
 
     override fun tick() {
         if(world?.isRemote == true){
@@ -26,7 +25,7 @@ class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), ITickableTileEn
      * Used when world is loaded an the tile entity is reconstructed.
      */
     override fun read(tag: CompoundNBT) {
-        incredients.ifPresent { it.deserializeNBT(tag.getCompound("inv")) }
+        ingredients.ifPresent { it.deserializeNBT(tag.getCompound("inv")) }
         super.read(tag)
     }
 
@@ -34,7 +33,7 @@ class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), ITickableTileEn
      * Used when world is saved. We have to store all data we want to keep over the world
      */
     override fun write(tag: CompoundNBT): CompoundNBT {
-        incredients.ifPresent { tag.put("inv", it.serializeNBT()) }
+        ingredients.ifPresent { tag.put("inv", it.serializeNBT()) }
         return super.write(tag)
     }
 
@@ -43,17 +42,17 @@ class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), ITickableTileEn
      */
     override fun <T : Any?> getCapability(cap: Capability<T>, side: Direction?): LazyOptional<T> {
         if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-            return incredients.cast()
+            return ingredients.cast()
         }
 
         return super.getCapability(cap, side)
     }
 
-    fun getStackInSlot(index: Int): ItemStack = incredients.map { it.getStackInSlot(index) }.orElse(ItemStack.EMPTY)
-    fun getSizeInventory(): Int = incredients.map { it.slots }.orElse(0)
+    fun getStackInSlot(index: Int): ItemStack = ingredients.map { it.getStackInSlot(index) }.orElse(ItemStack.EMPTY)
+    fun getSizeInventory(): Int = ingredients.map { it.slots }.orElse(0)
 
     override fun remove() {
-        incredients.invalidate()
+        ingredients.invalidate()
 
         super.remove()
     }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
@@ -47,7 +47,10 @@ class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), ITickableTileEn
         }
 
         return super.getCapability(cap, side)
-        }
+    }
+
+    fun getStackInSlot(index: Int): ItemStack = incredients.map { it.getStackInSlot(index) }.orElse(ItemStack.EMPTY)
+    fun getSizeInventory(): Int = incredients.map { it.slots }.orElse(0)
 
     override fun remove() {
         incredients.invalidate()

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
@@ -1,0 +1,22 @@
+package com.reicheltp.celtic_rituals.rituals.bowl
+
+import com.reicheltp.celtic_rituals.init.ModBlocks
+import net.minecraft.inventory.IInventory
+import net.minecraft.inventory.ItemStackHelper
+import net.minecraft.item.ItemStack
+import net.minecraft.nbt.CompoundNBT
+import net.minecraft.tileentity.ITickableTileEntity
+import net.minecraft.tileentity.TileEntity
+import net.minecraft.util.NonNullList
+import java.util.logging.LogManager
+
+/**
+ * TileEntity for @see RitualBowlBlock entity.
+ */
+class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), ITickableTileEntity {
+    override fun tick() {
+        if(world?.isRemote == true){
+            System.out.println("TICK")
+        }
+    }
+}

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
@@ -1,6 +1,9 @@
 package com.reicheltp.celtic_rituals.rituals.bowl
 
 import com.reicheltp.celtic_rituals.init.ModBlocks
+import com.reicheltp.celtic_rituals.utils.clear
+import com.reicheltp.celtic_rituals.utils.isEmpty
+import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.inventory.IInventory
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.CompoundNBT
@@ -17,7 +20,7 @@ import java.util.*
 /**
  * TileEntity for @see RitualBowlBlock entity.
  */
-class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!) {
+class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), IInventory {
     // The item handler capability keeps
     private val ingredients = LazyOptional.of { ItemStackHandler(5) }
 
@@ -43,7 +46,7 @@ class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!) {
     override fun <T : Any?> getCapability(cap: Capability<T>, side: Direction?): LazyOptional<T> {
         if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             // We can not push / pull new items as long as the ritual is running.
-            if(blockState.get(BlockStateProperties.ENABLED)){
+            if (blockState.get(BlockStateProperties.ENABLED)) {
                 return super.getCapability(cap, side)
             }
 
@@ -53,19 +56,24 @@ class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!) {
         return super.getCapability(cap, side)
     }
 
-    fun getStackInSlot(index: Int): ItemStack = ingredients.map { it.getStackInSlot(index) }.orElse(ItemStack.EMPTY)
-    fun getSizeInventory(): Int = ingredients.map { it.slots }.orElse(0)
+    override fun getStackInSlot(index: Int): ItemStack = ingredients.map { it.getStackInSlot(index) }.orElse(ItemStack.EMPTY)
+    override fun getSizeInventory(): Int = ingredients.map { it.slots }.orElse(0)
 
-    fun decrStackSize(index: Int, count: Int): ItemStack =
+    override fun decrStackSize(index: Int, count: Int): ItemStack =
             ingredients.map { it.extractItem(index, count, false) }.orElse(ItemStack.EMPTY)
 
-    fun setInventorySlotContents(index: Int, stack: ItemStack) =
+    override fun setInventorySlotContents(index: Int, stack: ItemStack) =
             ingredients.ifPresent { it.setStackInSlot(index, stack) }
 
-    fun removeStackFromSlot(index: Int): ItemStack =
+    override fun removeStackFromSlot(index: Int): ItemStack =
             ingredients.map { it.extractItem(index, 1, false) }.orElse(ItemStack.EMPTY)
 
-    fun clear() = ingredients.invalidate()
+    override fun clear() = ingredients.ifPresent { it.clear() }
+
+    override fun isEmpty(): Boolean = ingredients.map { it.isEmpty() }.orElse(true)
+
+    // TODO: Checkout what this method does
+    override fun isUsableByPlayer(player: PlayerEntity): Boolean = false
 
     override fun remove() {
         ingredients.invalidate()

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/RitualBowlTile.kt
@@ -51,6 +51,15 @@ class RitualBowlTile : TileEntity(ModBlocks.RITUAL_BOWL_TILE!!), ITickableTileEn
     fun getStackInSlot(index: Int): ItemStack = ingredients.map { it.getStackInSlot(index) }.orElse(ItemStack.EMPTY)
     fun getSizeInventory(): Int = ingredients.map { it.slots }.orElse(0)
 
+    fun decrStackSize(index: Int, count: Int): ItemStack =
+            ingredients.map { it.extractItem(index, count, false) }.orElse(ItemStack.EMPTY)
+
+    fun setInventorySlotContents(index: Int, stack: ItemStack) =
+            ingredients.ifPresent { it.setStackInSlot(index, stack) }
+
+    fun removeStackFromSlot(index: Int): ItemStack =
+            ingredients.map { it.extractItem(index, 1, false) }.orElse(ItemStack.EMPTY)
+
     override fun remove() {
         ingredients.invalidate()
 

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/utils/ItemHelper.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/utils/ItemHelper.kt
@@ -1,0 +1,15 @@
+package com.reicheltp.celtic_rituals.utils
+
+import net.minecraft.item.ItemStack
+
+/**
+ * Returns true if both stacks match an can be combined to a single one.
+ */
+fun ItemStack.canBeCombined(stack2: ItemStack): Boolean {
+    return when {
+        this.item !== stack2.item -> false
+        this.damage != stack2.damage -> false
+        this.count > this.maxStackSize -> false
+        else -> ItemStack.areItemStackTagsEqual(this, stack2)
+    }
+}

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/utils/ItemHelper.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/utils/ItemHelper.kt
@@ -1,6 +1,8 @@
 package com.reicheltp.celtic_rituals.utils
 
+import com.sun.org.apache.xpath.internal.operations.Bool
 import net.minecraft.item.ItemStack
+import net.minecraftforge.items.ItemStackHandler
 
 /**
  * Returns true if both stacks match an can be combined to a single one.
@@ -12,4 +14,26 @@ fun ItemStack.canBeCombined(stack2: ItemStack): Boolean {
         this.count > this.maxStackSize -> false
         else -> ItemStack.areItemStackTagsEqual(this, stack2)
     }
+}
+
+/**
+ * Sets all slots empty.
+ */
+fun ItemStackHandler.clear() {
+    for(i in 0 until this.slots){
+        this.setStackInSlot(i, ItemStack.EMPTY)
+    }
+}
+
+/**
+ * Sets all slots empty.
+ */
+fun ItemStackHandler.isEmpty(): Boolean {
+    for(i in 0 until this.slots){
+        if (!this.getStackInSlot(i).isEmpty){
+            return false
+        }
+    }
+
+    return true
 }

--- a/src/main/resources/assets/celtic_rituals/blockstates/ritual_bowl.json
+++ b/src/main/resources/assets/celtic_rituals/blockstates/ritual_bowl.json
@@ -1,7 +1,45 @@
 {
-  "variants": {
-    "": {
-      "model": "celtic_rituals:block/ritual_bowl"
+  "multipart": [
+    {
+      "apply": { "model": "celtic_rituals:block/ritual_bowl" }
+    },
+    {   "when": { "enabled": true },
+      "apply": [
+        { "model": "celtic_rituals:block/fire_floor0" },
+        { "model": "celtic_rituals:block/fire_floor1" }
+      ]
+    },
+    {   "when": { "enabled": true },
+      "apply": [
+        { "model": "celtic_rituals:block/fire_side0" },
+        { "model": "celtic_rituals:block/fire_side1" },
+        { "model": "celtic_rituals:block/fire_side_alt0" },
+        { "model": "celtic_rituals:block/fire_side_alt1" }
+      ]
+    },
+    {   "when": { "enabled": true },
+      "apply": [
+        { "model": "celtic_rituals:block/fire_side0", "y": 90 },
+        { "model": "celtic_rituals:block/fire_side1", "y": 90 },
+        { "model": "celtic_rituals:block/fire_side_alt0", "y": 90 },
+        { "model": "celtic_rituals:block/fire_side_alt1", "y": 90 }
+      ]
+    },
+    {   "when": { "enabled": true },
+      "apply": [
+        { "model": "celtic_rituals:block/fire_side0", "y": 180 },
+        { "model": "celtic_rituals:block/fire_side1", "y": 180 },
+        { "model": "celtic_rituals:block/fire_side_alt0", "y": 180 },
+        { "model": "celtic_rituals:block/fire_side_alt1", "y": 180 }
+      ]
+    },
+    {   "when": { "enabled": true },
+      "apply": [
+        { "model": "celtic_rituals:block/fire_side0", "y": 270 },
+        { "model": "celtic_rituals:block/fire_side1", "y": 270 },
+        { "model": "celtic_rituals:block/fire_side_alt0", "y": 270 },
+        { "model": "celtic_rituals:block/fire_side_alt1", "y": 270 }
+      ]
     }
-  }
+  ]
 }

--- a/src/main/resources/assets/celtic_rituals/blockstates/ritual_bowl.json
+++ b/src/main/resources/assets/celtic_rituals/blockstates/ritual_bowl.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "celtic_rituals:block/ritual_bowl"
+    }
+  }
+}

--- a/src/main/resources/assets/celtic_rituals/lang/en_us.json
+++ b/src/main/resources/assets/celtic_rituals/lang/en_us.json
@@ -1,3 +1,5 @@
 {
-  "item.celtic_rituals.knife": "Druid Knife"
+  "item.celtic_rituals.knife": "Druid Knife",
+  "item.celtic_rituals.ritual_bowl": "Ritual Bowl",
+  "block.celtic_rituals.ritual_bowl": "Ritual Bowl"
 }

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_floor.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_floor.json
@@ -1,0 +1,29 @@
+{
+    "ambientocclusion": false,
+    "elements": [
+        {   "from": [ 2, 2, 8.8 ],
+            "to": [ 14, 22.4, 8.8 ],
+            "rotation": { "origin": [ 8, 8, 8 ], "axis": "x", "angle": -22.5, "rescale": true },
+            "shade": false,
+            "faces": { "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#fire" }}
+        },
+        {   "from": [ 2, 2, 7.2 ],
+            "to": [ 14, 22.4, 7.2 ],
+            "rotation": { "origin": [ 8, 8, 8 ], "axis": "x", "angle": 22.5, "rescale": true },
+            "shade": false,
+            "faces": { "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#fire" }}
+        },
+        {   "from": [ 8.8, 2, 0 ],
+            "to": [ 8.8, 22.4, 14 ],
+            "rotation": { "origin": [ 8, 8, 8 ], "axis": "z", "angle": -22.5, "rescale": true },
+            "shade": false,
+            "faces": { "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#fire" }}
+        },
+        {   "from": [ 7.2, 2, 0 ],
+            "to": [ 7.2, 22.4, 14 ],
+            "rotation": { "origin": [ 8, 8, 8 ], "axis": "z", "angle": 22.5, "rescale": true },
+            "shade": false,
+            "faces": { "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#fire" }}
+        }
+    ]
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_floor0.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_floor0.json
@@ -1,0 +1,7 @@
+{
+    "parent": "celtic_rituals:block/fire_floor",
+    "textures": {
+        "particle": "block/fire_0",
+        "fire": "block/fire_0"
+    }
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_floor1.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_floor1.json
@@ -1,0 +1,7 @@
+{
+    "parent": "celtic_rituals:block/fire_floor",
+    "textures": {
+        "particle": "block/fire_1",
+        "fire": "block/fire_1"
+    }
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_side.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_side.json
@@ -1,0 +1,13 @@
+{
+    "ambientocclusion": false,
+    "elements": [
+        {   "from": [ 2, 2, 2.01 ],
+            "to": [ 14, 22.4, 2.01 ],
+            "shade": false,
+            "faces": {
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#fire" },
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#fire" }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_side0.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_side0.json
@@ -1,0 +1,7 @@
+{
+    "parent": "celtic_rituals:block/fire_side",
+    "textures": {
+        "particle": "block/fire_0",
+        "fire": "block/fire_0"
+    }
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_side1.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_side1.json
@@ -1,0 +1,7 @@
+{
+    "parent": "celtic_rituals:block/fire_side",
+    "textures": {
+        "particle": "block/fire_1",
+        "fire": "block/fire_1"
+    }
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_side_alt.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_side_alt.json
@@ -1,0 +1,13 @@
+{
+    "ambientocclusion": false,
+    "elements": [
+        {   "from": [ 2, 2, 2.01 ],
+            "to": [ 14, 22.4, 2.01 ],
+            "shade": false,
+            "faces": {
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#fire" },
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#fire" }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_side_alt0.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_side_alt0.json
@@ -1,0 +1,7 @@
+{
+    "parent": "celtic_rituals:block/fire_side_alt",
+    "textures": {
+        "particle": "block/fire_0",
+        "fire": "block/fire_0"
+    }
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/fire_side_alt1.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/fire_side_alt1.json
@@ -1,0 +1,7 @@
+{
+    "parent": "celtic_rituals:block/fire_side_alt",
+    "textures": {
+        "particle": "block/fire_1",
+        "fire": "block/fire_1"
+    }
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/ritual_bowl.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/ritual_bowl.json
@@ -1,0 +1,8 @@
+{
+  "parent": "celtic_rituals:block/template_ritual_bowl",
+  "textures": {
+    "cap": "minecraft:block/oak_log_top",
+    "side": "minecraft:block/oak_log",
+    "inside": "minecraft:block/stripped_oak_log"
+  }
+}

--- a/src/main/resources/assets/celtic_rituals/models/block/template_ritual_bowl.json
+++ b/src/main/resources/assets/celtic_rituals/models/block/template_ritual_bowl.json
@@ -1,0 +1,73 @@
+{
+  "parent": "minecraft:block/block",
+  "textures": {
+    "particle": "#side"
+  },
+  "elements": [
+    {
+      "__comment": "Box1",
+      "from": [2, 0, 2],
+      "to": [14, 4, 14],
+      "faces": {
+        "down": { "uv": [2, 2, 14, 14], "texture": "#cap" },
+        "up": { "uv": [2, 2, 14, 14], "texture": "#cap" },
+        "north": { "uv": [2, 12, 14, 16], "texture": "#inside" },
+        "south": { "uv": [2, 12, 14, 16], "texture": "#inside" },
+        "west": { "uv": [2, 12, 14, 16], "texture": "#inside" },
+        "east": { "uv": [2, 12, 14, 16], "texture": "#inside" }
+      }
+    },
+    {
+      "__comment": "Box2",
+      "from": [2, 2, 0],
+      "to": [14, 8, 2],
+      "faces": {
+        "down": { "uv": [2, 14, 14, 16], "texture": "#cap" },
+        "up": { "uv": [2, 0, 14, 2], "texture": "#cap" },
+        "north": { "uv": [2, 8, 14, 14], "texture": "#side" },
+        "south": { "uv": [2, 8, 14, 14], "texture": "#inside" },
+        "west": { "uv": [0, 8, 2, 14], "texture": "#side" },
+        "east": { "uv": [14, 8, 16, 14], "texture": "#side" }
+      }
+    },
+    {
+      "__comment": "Box3",
+      "from": [2, 2, 14],
+      "to": [14, 8, 16],
+      "faces": {
+        "down": { "uv": [2, 0, 14, 2], "texture": "#cap" },
+        "up": { "uv": [2, 14, 14, 16], "texture": "#cap" },
+        "north": { "uv": [2, 8, 14, 14], "texture": "#inside" },
+        "south": { "uv": [2, 8, 14, 14], "texture": "#side" },
+        "west": { "uv": [14, 8, 16, 14], "texture": "#side" },
+        "east": { "uv": [0, 8, 2, 14], "texture": "#side" }
+      }
+    },
+    {
+      "__comment": "Box4",
+      "from": [14, 2, 2],
+      "to": [16, 8, 14],
+      "faces": {
+        "down": { "uv": [14, 2, 16, 14], "texture": "#cap" },
+        "up": { "uv": [14, 2, 16, 14], "texture": "#cap" },
+        "north": { "uv": [0, 8, 2, 14], "texture": "#side" },
+        "south": { "uv": [14, 8, 16, 14], "texture": "#side" },
+        "west": { "uv": [2, 8, 14, 14], "texture": "#inside" },
+        "east": { "uv": [2, 8, 14, 14], "texture": "#side" }
+      }
+    },
+    {
+      "__comment": "Box5",
+      "from": [0, 2, 2],
+      "to": [2, 8, 14],
+      "faces": {
+        "down": { "uv": [0, 2, 2, 14], "texture": "#cap" },
+        "up": { "uv": [0, 2, 2, 14], "texture": "#cap" },
+        "north": { "uv": [14, 8, 16, 14], "texture": "#side" },
+        "south": { "uv": [0, 8, 2, 14], "texture": "#side" },
+        "west": { "uv": [2, 8, 14, 14], "texture": "#side" },
+        "east": { "uv": [2, 8, 14, 14], "texture": "#inside" }
+      }
+    }
+  ]
+}

--- a/src/main/resources/assets/celtic_rituals/models/item/ritual_bowl.json
+++ b/src/main/resources/assets/celtic_rituals/models/item/ritual_bowl.json
@@ -1,0 +1,3 @@
+{
+  "parent": "celtic_rituals:block/ritual_bowl"
+}

--- a/src/main/resources/data/celtic_rituals/loot_tables/blocks/ritual_bowl.json
+++ b/src/main/resources/data/celtic_rituals/loot_tables/blocks/ritual_bowl.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "ritual_bowl",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "celtic_rituals:ritual_bowl",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/celtic_rituals/recipes/ritual_bowl.json
+++ b/src/main/resources/data/celtic_rituals/recipes/ritual_bowl.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "tag": "minecraft:logs"
+    }
+  },
+  "result": {
+    "item": "celtic_rituals:ritual_bowl"
+  }
+}


### PR DESCRIPTION
This PR introduces the ritual bow, which is part of all rituals requiring items.

### Requirements
- [x] Player can craft the bowl
- [x] Player can place the bowl on ground and pick it up
- [x] Player can put items in the bowl (right click with items in the hand)
- [x] Items are dropped when bowl is picked up
- [x] Player can ignite (flint & steal) the bowl to perform a ritual