### PR TITLE
Extend Potion Effect and Recipe Color

### DIFF
--- a/docs/effects.md
+++ b/docs/effects.md
@@ -37,6 +37,8 @@ Creates a new `AreaEffectCloud` originating at the bowl.
 | potion | Name of the potion. E.g. `minecraft:healing` |
 | duration | **(optional)** Time in ticks the area is effected. Defaults to 60 |
 | radius | **(optional)** Radius, which is effected. Defaults to 3.0 |
+| particle | **(optional)** Name of particle data. Defaults to `minecraft:entity_effect` |
+| color | **(optional)** Color of the cloud. Either number or hex string. Defaults to 0 |
 
 
 

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/effects/PotionEffect.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/effects/PotionEffect.kt
@@ -2,18 +2,24 @@ package com.reicheltp.celtic_rituals.effects
 
 import com.google.gson.JsonObject
 import com.reicheltp.celtic_rituals.MOD_ID
+import com.reicheltp.celtic_rituals.utils.asColor
 import net.minecraft.entity.AreaEffectCloudEntity
 import net.minecraft.inventory.IInventory
 import net.minecraft.network.PacketBuffer
+import net.minecraft.particles.IParticleData
+import net.minecraft.particles.ParticleTypes
 import net.minecraft.potion.Potion
 import net.minecraft.util.ResourceLocation
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.World
+import net.minecraftforge.registries.ForgeRegistries
 
 class PotionEffect(
   private val potion: Potion,
   private val duration: Int,
-  private val radius: Float
+  private val radius: Float,
+  private val particle: String,
+  private val color: Int
 ) : IEffect {
     override fun apply(world: World, pos: BlockPos, inv: IInventory): Boolean {
         val entity =
@@ -22,6 +28,8 @@ class PotionEffect(
         entity.duration = duration
         entity.setPotion(potion)
         entity.radius = radius
+        entity.particleData = lookupParticle(particle)
+        entity.color = color
 
         world.addEntity(entity)
 
@@ -42,7 +50,9 @@ class PotionEffect(
                 return PotionEffect(
                     Potion.getPotionTypeForName(potion),
                     element.get("duration")?.asInt ?: 60,
-                    element.get("radius")?.asFloat ?: 3.0f
+                    element.get("radius")?.asFloat ?: 3.0f,
+                    element.get("particle")?.asString ?: "",
+                    element.get("color")?.asColor ?: 0
                 )
             }
 
@@ -50,14 +60,31 @@ class PotionEffect(
                 return PotionEffect(
                     Potion.getPotionTypeForName(buffer.readString()),
                     buffer.readInt(),
-                    buffer.readFloat()
+                    buffer.readFloat(),
+                    buffer.readString(),
+                    buffer.readInt()
                 )
             }
 
             override fun write(buffer: PacketBuffer, effect: PotionEffect) {
                 buffer.writeString(effect.potion.registryName.toString())
                 buffer.writeInt(effect.duration)
+                buffer.writeFloat(effect.radius)
+                buffer.writeString(effect.particle)
+                buffer.writeInt(effect.color)
             }
+        }
+
+        /**
+         * Looks into registry for a particle data with given name.
+         */
+        private fun lookupParticle(particleName: String): IParticleData {
+            val id = ResourceLocation(particleName)
+
+            if (ForgeRegistries.PARTICLE_TYPES.containsKey(id))
+                return ForgeRegistries.PARTICLE_TYPES.getValue(id) as IParticleData
+            else
+                return ParticleTypes.ENTITY_EFFECT
         }
     }
 }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bag/RitualBagItem.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bag/RitualBagItem.kt
@@ -29,11 +29,17 @@ class RitualBagItem : Item(Properties().setNoRepair().group(ModItemGroups.DEFAUL
     companion object {
         private const val EMPTY_COLOR = 0x70472D
 
+        /**
+         * Picks a tint color from contained recipe.
+         */
         fun getColor(item: ItemStack): Int {
-            // TODO: Pick color for ritual bag based on ritual
-            val hasRecipe = item.hasTag() && item.tag?.get("recipe") !== null
+            val recipe = getRecipe(item)
+            if (!recipe.isPresent) {
+                return EMPTY_COLOR
+            }
 
-            return if (hasRecipe) 0xF800F8 else EMPTY_COLOR
+            val color = recipe.get().color
+            return if (color > 0) color else 0xF800F8
         }
 
         fun getRecipe(item: ItemStack): Optional<BowlRitualRecipe> {

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bag/RitualBagItem.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bag/RitualBagItem.kt
@@ -160,4 +160,17 @@ class RitualBagItem : Item(Properties().setNoRepair().group(ModItemGroups.DEFAUL
 
         return 16
     }
+
+    /**
+     * Returns the unlocalized name of this item. This version accepts an ItemStack so different stacks can have
+     * different names based on their damage or NBT.
+     */
+    override fun getTranslationKey(item: ItemStack): String {
+        if (item.tag?.contains("recipe") != true) {
+            return this.translationKey
+        }
+
+        val name = ResourceLocation(item.tag!!.getString("recipe"))
+        return this.translationKey + ".ritual." + name.path
+    }
 }

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/BowlRitualRecipe.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bowl/BowlRitualRecipe.kt
@@ -10,6 +10,7 @@ import com.reicheltp.celtic_rituals.effects.IEffect
 import com.reicheltp.celtic_rituals.effects.readEffectList
 import com.reicheltp.celtic_rituals.effects.writeEffectList
 import com.reicheltp.celtic_rituals.init.ModRecipes
+import com.reicheltp.celtic_rituals.utils.asColor
 import net.minecraft.inventory.IInventory
 import net.minecraft.item.ItemStack
 import net.minecraft.item.crafting.IRecipe
@@ -30,7 +31,8 @@ class BowlRitualRecipe(
   /**
    * Duration in ticks, this recipe has to burn. Defaults to 60 (3s)
    */
-  val duration: Int
+  val duration: Int,
+  val color: Int
 ) : IRecipe<RitualBowlTile> {
     companion object {
         const val DEFAULT_DURATION = 60
@@ -91,8 +93,9 @@ class BowlRitualRecipe(
             val result = parseResults(json.get("result"))
 
             val duration = json.get("duration")?.asInt ?: DEFAULT_DURATION
+            val color = json.get("color")?.asColor ?: -1
 
-            return BowlRitualRecipe(recipeId, ingredients, result, duration)
+            return BowlRitualRecipe(recipeId, ingredients, result, duration, color)
         }
 
         override fun write(buffer: PacketBuffer, recipe: BowlRitualRecipe) {
@@ -101,6 +104,7 @@ class BowlRitualRecipe(
 
             buffer.writeEffectList(recipe.result)
             buffer.writeInt(recipe.duration)
+            buffer.writeInt(recipe.color)
         }
 
         override fun read(recipeId: ResourceLocation, buffer: PacketBuffer): BowlRitualRecipe? {
@@ -112,8 +116,9 @@ class BowlRitualRecipe(
 
             val result = buffer.readEffectList()
             val duration = buffer.readInt()
+            val color = buffer.readInt()
 
-            return BowlRitualRecipe(recipeId, ingredients, result, duration)
+            return BowlRitualRecipe(recipeId, ingredients, result, duration, color)
         }
 
         private fun parseResults(element: JsonElement): List<IEffect> {

--- a/src/main/kotlin/com/reicheltp/celtic_rituals/utils/JsonHelper.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/utils/JsonHelper.kt
@@ -1,0 +1,25 @@
+package com.reicheltp.celtic_rituals.utils
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.lang.Integer.parseInt
+
+/**
+ * Parses a json element to a color represented as int.
+ *
+ * Thus, 16253176 and "F800F8" are both valid colors.
+ */
+val JsonElement.asColor: Int
+    get() {
+        if (!this.isJsonPrimitive) {
+            throw JsonParseException("color should be number or string")
+        }
+
+        val value = this.asJsonPrimitive
+
+        return when {
+            value.isNumber -> value.asInt
+            value.isString -> parseInt(value.asString, 16)
+            else -> throw JsonParseException("color should be number or string")
+        }
+    }

--- a/src/main/resources/assets/celtic_rituals/lang/en_us.json
+++ b/src/main/resources/assets/celtic_rituals/lang/en_us.json
@@ -4,5 +4,6 @@
   "item.celtic_rituals.knife": "Druid Knife",
   "item.celtic_rituals.ritual_bowl": "Ritual Bowl",
   "item.celtic_rituals.ritual_bag": "Ritual Bag",
+  "item.celtic_rituals.ritual_bag.ritual.healing_ritual": "Bag of Healing",
   "block.celtic_rituals.ritual_bowl": "Ritual Bowl"
 }

--- a/src/main/resources/data/celtic_rituals/recipes/healing_ritual.json
+++ b/src/main/resources/data/celtic_rituals/recipes/healing_ritual.json
@@ -20,7 +20,9 @@
       "effect": "celtic_rituals:potion",
       "potion": "minecraft:healing",
       "radius": 5.0,
-      "duration": 120
+      "duration": 120,
+      "particle": "minecraft:heart",
+      "color": 16253176
     },
     {
       "effect": "celtic_rituals:change_weather",

--- a/src/main/resources/data/celtic_rituals/recipes/healing_ritual.json
+++ b/src/main/resources/data/celtic_rituals/recipes/healing_ritual.json
@@ -1,5 +1,6 @@
 {
   "type": "celtic_rituals:bowl_ritual",
+  "color": "00F800",
   "ingredients": [
     {
       "item": "minecraft:redstone"


### PR DESCRIPTION
- Extend a potion effect to support `particle` and `color` option
- Extend bowl ritual recipe to support `color` prop which defines the color of the bag
- Dynamically build translation key for bags containing a ritual