### PR TITLE
FIX: Ritual bag use on block

### DIFF
--- a/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bag/RitualBagItem.kt
+++ b/src/main/kotlin/com/reicheltp/celtic_rituals/rituals/bag/RitualBagItem.kt
@@ -104,7 +104,7 @@ class RitualBagItem : Item(Properties().setNoRepair().group(ModItemGroups.DEFAUL
     override fun onItemUse(context: ItemUseContext): ActionResultType {
         if (getRecipe(context.item).isPresent) {
             // You can only fill empty bags
-            return ActionResultType.FAIL
+            return ActionResultType.PASS
         }
 
         val state = context.world.getBlockState(context.pos)


### PR DESCRIPTION
- ritual bag with effect should also be thrown, when right clicked on a block